### PR TITLE
Internet Explorer 6+ support

### DIFF
--- a/stativus.js
+++ b/stativus.js
@@ -126,9 +126,10 @@ Stativus.Statechart = {
 		  sc.inState = function(name, tree){
 		    var ret = false, cStates = this.currentState(tree);
 		    if (!cStates) throw "Doesn't appear that you are in any states, perhaps you forgot to 'initStates'?";
-        cStates.forEach( function(x){
+        for (var idx = 0; idx < cStates.length; idx++) {
+          var x = cStates[idx];
           if(x.name === name) ret = true;
-        });
+        }
         return ret;
 		  };
 		  sc.getActiveStates = sc.currentState;
@@ -193,8 +194,9 @@ Stativus.Statechart = {
         throw ['Trying to add substates in property \'states\' to '+nState.name+', but must have more than ONE substate'];
       }
     }
-    
-    states.forEach( function(x, idx){
+   
+    for (var idx = 0; idx < states.length; idx++) {
+      var x = states[idx];
       var args = [], good = false, last;
       if(typeof x === 'object' && x.length > 0){
         if (DEBUG_MODE){
@@ -226,7 +228,7 @@ Stativus.Statechart = {
       } else {
         if (DEBUG_MODE) throw '#addState: invalid substate at index='+idx; 
       }
-    });
+    }
     
     return this;
   },
@@ -585,7 +587,8 @@ Stativus.Statechart = {
       nTree = [Stativus.SUBSTATE_DELIM,tree,name].join('=>');
       start.history = start.history || {};
       subStates = start.substates || [];
-      subStates.forEach( function(x){
+      for (var idx = 0; idx < subStates.length; idx++) {
+        var x = subStates[idx];
         nTree = tree+'=>'+x;
         cState = allStates[x];
 
@@ -598,7 +601,7 @@ Stativus.Statechart = {
 
         if (index > -1 && requiredStates[index] === cState) index -= 1;
         that._cascadeEnterSubstates(cState, requiredStates, index, nTree, allStates);
-	    });
+	    }
 	    return;        
     }
     else {
@@ -632,8 +635,9 @@ Stativus.Statechart = {
     allStates = this._all_states[tree];
     cStates = this._current_state;
     this._exitStateStack = this._exitStateStack || [];
-    
-    stopState.substates.forEach( function(state){
+   
+    for (var idx = 0; idx < stopState.substates.length; idx++) {
+      var state = stopState.substates[idx];
       var substateTree, currState, curr, exitStateHandled, aTrees;
       substateTree = [Stativus.SUBSTATE_DELIM, tree, stopState.name, state].join('=>');
 	    currState = cStates[substateTree];
@@ -652,7 +656,7 @@ Stativus.Statechart = {
 	    
 	    // Now, remove this from the active substate tree
 	    that._active_subtrees[tree] = that._removeFromActiveTree(tree, substateTree);
-    });
+    }
   },
   
   // @private
@@ -740,9 +744,9 @@ Stativus.Statechart = {
     if (!aTrees) return [];
     if (!tree) return aTrees;
 
-    aTrees.forEach( function(x){
+    for (var idx = 0;idx < aTrees.length; idx++) {
       if(x !== tree) nArray.push(x);
-    });
+    }
     
     return nArray;
   },
@@ -779,10 +783,11 @@ if (EVENTABLE){
     if (!node || !node.className) return;
     selectors = node.className.split(/\s+/).map( function(x){ return '.'+x; });
     if (node.id) selectors.push('#'+node.id);
-    selectors.forEach( function(x){
+    for (var idx = 0;idx < selectors.length; idx++) {
+      var x = selectors[idx];
       lookup = (x+' '+evt).replace(/^\s\s*/, '').replace(/\s\s*$/, '');
       that._structureCrawl('_cascadeActionHandler', lookup, args);
-    });
+    }
   };
   
   Stativus.Statechart._cascadeActionHandler = function(lookup, args, responder, allStates, tree){


### PR DESCRIPTION
This will address stativus support for Internet Explorer 6+ (windows XP SP2 base install). The lag of `forEach` and `indexOf` support in <IE9 raises a permission denied error on production installations right now.
