### PR TITLE
ECMAScript 5 support for Internet Explorer 6.0+

### DIFF
--- a/stativus.js
+++ b/stativus.js
@@ -10,6 +10,36 @@ if (!Array.prototype.indexOf) {
   }
 }
 
+// Adds indexOf support for <IE8
+// https://developer.mozilla.org/En/Core_JavaScript_1.5_Reference:Objects:Array:forEach#Compatibility
+// Production steps of ECMA-262, Edition 5, 15.4.4.18
+// Reference: http://es5.github.com/#x15.4.4.18
+if (!Array.prototype.forEach) {
+  Array.prototype.forEach = function( callback, thisArg ) {
+    var T, k;
+    if ( this == null ) {
+      throw new TypeError( " this is null or not defined" );
+    }
+    var O = Object(this);
+    var len = O.length >>> 0; // Hack to convert O.length to a UInt32
+    if ( {}.toString.call(callback) != "[object Function]" ) {
+      throw new TypeError( callback + " is not a function" );
+    }
+    if ( thisArg ) {
+      T = thisArg;
+    }
+    k = 0;
+    while( k < len ) {
+      var kValue;
+      if ( k in O ) {
+        kValue = O[ k ];
+        callback.call( T, kValue, k, O );
+      }
+      k++;
+    }
+  };
+}
+
 /**
   This is the code for creating statecharts in your javascript files
   


### PR DESCRIPTION
This will address stativus support for Internet Explorer 6+ (windows XP SP2 base install). The lag of forEach and indexOf support in <IE9 raises a permission denied error on production installations right now.

etgryphon/#40 pointed out that there is https://github.com/kriskowal/es5-shim for that
