### PR TITLE
Added support for coloured log messages in Chrome

### DIFF
--- a/stativus.js
+++ b/stativus.js
@@ -9,6 +9,11 @@
 if (typeof DEBUG_MODE === "undefined"){
   DEBUG_MODE = true;
   COLOR_MODE = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
+  if (COLOR_MODE) {
+    EVENT_COLOR = "#CC00FF";
+    ENTER_COLOR = "#009900";
+    EXIT_COLOR = "#880000";
+  }
 }
 
 // Pre-processor for eventable code
@@ -480,7 +485,7 @@ Stativus.Statechart = {
       if (responder[evt]){
         if (DEBUG_MODE) {
         	var msg = ['EVENT:',responder.name,'fires','['+evt+']', 'with', args.length || 0, 'argument(s)'].join(' ');
-        	(COLOR_MODE) ? console.log('%c' + msg, "color:#CC00FF") : console.log(msg);
+        	(COLOR_MODE) ? console.log('%c' + msg, "color:" + EVENT_COLOR) : console.log(msg);
         }
         handled = responder[evt].apply(responder, args);
         found = true;
@@ -525,7 +530,7 @@ Stativus.Statechart = {
   _fullEnter: function(state){
     var pState, enterStateHandled = false;
     if (!state) return;
-    if (DEBUG_MODE) (COLOR_MODE) ? console.log('%cENTER: '+state.name, "color:#009900;font-weight:bold;") : console.log('ENTER: '+state.name);
+    if (DEBUG_MODE) (COLOR_MODE) ? console.log('%cENTER: '+state.name, "color:" + ENTER_COLOR + ";font-weight:bold;") : console.log('ENTER: '+state.name);
     if (state.enterState) state.enterState();
     if (state.didEnterState) state.didEnterState();
     if (state.parentState) {
@@ -541,7 +546,7 @@ Stativus.Statechart = {
     var exitStateHandled = false;
     if (state.exitState) state.exitState();
     if (state.didExitState) state.didExitState();
-    if (DEBUG_MODE) (COLOR_MODE) ? console.log('%cEXIT: '+state.name, "color:#880000") : console.log('EXIT: '+state.name);
+    if (DEBUG_MODE) (COLOR_MODE) ? console.log('%cEXIT: '+state.name, "color:" + EXIT_COLOR) : console.log('EXIT: '+state.name);
     this._unwindExitStateStack();
   },
   


### PR DESCRIPTION
When debugging Stativus in the browser there can be a bit stream of messages and it can be hard to pick out the important bits.  This commit simply makes ENTER messages green, EXIT messages red and ACTION messages purple (in Chrome) which makes debugging in the browser much easier on the eyes.
